### PR TITLE
fix links to allanbowe/BizarroBall

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ cat > $BBFILE <<'EOL'
 /**
   @file
   @brief Auto-generated file
-  @details The `build.sh` file in the https://github.com/allanbowe/bizarro repo
+  @details The `build.sh` file in the https://github.com/allanbowe/bizarroball repo
     is used to create this file.
   @author Allan Bowe (derivative of work by Don Henderson and Paul Dorfman)
   ///@cond INTERNAL

--- a/doxy/main.dox
+++ b/doxy/main.dox
@@ -1,5 +1,5 @@
 /** \dir ..
- *  \brief Open Source Bizarro Ball data for SAS Developers.  See: https://github.com/allanbowe/bizarro
+ *  \brief Open Source Bizarro Ball data for SAS Developers.  See: https://github.com/allanbowe/bizarroball
  *  \details To use - run the bizarro.sas program in the repo root.
  */
 

--- a/doxy/new_footer.html
+++ b/doxy/new_footer.html
@@ -2,7 +2,7 @@
     <li class="footer"><b>$generatedby</b>
     <a href="http://www.doxygen.org/index.html">
     <img class="footer" src="doxygen.png" alt="doxygen"/></a>  
-   <i> For more information visit the </i> <a href="https://github.com/allanbowe/bizarro">Bizarro Ball library</a>.</li>
+   <i> For more information visit the </i> <a href="https://github.com/allanbowe/bizarroball">Bizarro Ball library</a>.</li>
   
    </ul>
  </div>
@@ -10,7 +10,7 @@
 <!--BEGIN !GENERATE_TREEVIEW-->
 <hr class="footer"/>
 <table width="100%"><tbody><tr><td>
-For more information visit the <a href="https://github.com/allanbowe/bizarro">Bizarrro Ball library</a>.
+For more information visit the <a href="https://github.com/allanbowe/bizarroball">Bizarrro Ball library</a>.
 </td><td><address class="footer"><small>
 &copy;$year<br/>
 $generatedby <a href="http://www.doxygen.org/index.html">


### PR DESCRIPTION
I noticed the links were broken on the [GitHub.io site](https://allanbowe.github.io/bizarro.github.io/), so I fixed them.